### PR TITLE
Remove overwriting of background color

### DIFF
--- a/Endless.podspec
+++ b/Endless.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Endless'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'Endless is a lighweight endless page indicator.'
 
   s.description      = <<-DESC

--- a/Endless/Classes/public/Indicator.swift
+++ b/Endless/Classes/public/Indicator.swift
@@ -9,7 +9,6 @@ public final class Indicator: UIView, IndicatorProtocol {
         collectionView.backgroundColor = .clear
         collectionView.allowsMultipleSelection = false
         (collectionView.collectionViewLayout as? UICollectionViewFlowLayout)?.scrollDirection = .horizontal
-        collectionView.backgroundColor = UIColor.white
         collectionView.register(IndicatorCell.self, forCellWithReuseIdentifier: Constants.indicatorCellReuseIdentifier)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.isUserInteractionEnabled = false


### PR DESCRIPTION
Three lines above, `collectionView.backgroundColor = .clear` is called. Then, `collectionView.backgroundColor UIColor.white` is called. Clear seems to be a better option.